### PR TITLE
Must return string or ``None``

### DIFF
--- a/translationstring/__init__.py
+++ b/translationstring/__init__.py
@@ -176,6 +176,9 @@ def ChameleonTranslate(translator):
         # spray these indignant comments all over this module. ;-)
 
         if not isinstance(msgid, basestring):
+            if msgid is not None:
+                msgid = str(msgid)
+
             return msgid
 
         tstring = msgid

--- a/translationstring/tests/test__init__.py
+++ b/translationstring/tests/test__init__.py
@@ -119,6 +119,11 @@ class TestChameleonTranslate(unittest.TestCase):
         result = translate(None)
         self.assertEqual(result, None)
 
+    def test_msgid_not_none_not_string(self):
+        translate = self._makeOne(None)
+        result = translate(True)
+        self.assertEqual(result, 'True')
+
     def test_chameleon_default_marker_returned(self):
         # Chameleon uses a special StringMarker class as default value so it
         # can detect missing translations.


### PR DESCRIPTION
As shown in the test, an example of another such object is `True`; we must coerce this to a string. It might be an error by the developer, but the translate contract is clear: strings or `None`.
