### PR TITLE
Apply mapped values when coercing to native string.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,10 @@ translationstring
 Next release
 ------------
 
+- Implement custom equality operator that compares favorably to both a
+  string identical to the message id, and to the interpolated string
+  representation.
+
 - Return the result of ``interpolate()`` as the string representation
   instead of the message id.
 

--- a/translationstring/__init__.py
+++ b/translationstring/__init__.py
@@ -84,6 +84,17 @@ class TranslationString(text_type):
         self.mapping = mapping
         return self
 
+    def __eq__(self, other):
+        # First compare strings with strings; this tests that the
+        # original message string compares favorably to an identical
+        # string.
+        string = text_type(other)
+        if text_type.__eq__(self, string):
+            return True
+
+        # Next, interpolate and compare the result.
+        return self.interpolate() == string
+
     def __mod__(self, options):
         """Create a new TranslationString instance with an updated mapping.
         This makes it possible to use the standard python %-style string

--- a/translationstring/tests/test__init__.py
+++ b/translationstring/tests/test__init__.py
@@ -28,8 +28,9 @@ class TestTranslationString(unittest.TestCase):
         mapping = {"name": "Zope", "version": 3}
         inst = self._makeOne('This is $name version ${version}.',
                              mapping=mapping)
-        self.assertEqual(str(inst), inst)
-        self.assertEqual(inst, str(inst))
+        result = 'This is Zope version 3.'
+        self.assertEqual(result, inst)
+        self.assertEqual(inst, result)
 
     def test_default_None(self):
         inst = self._makeOne('msgid')


### PR DESCRIPTION
- When a translation string is coerced to its native string type
  (i.e. the built-in string or unicode type), the default translation
  (or msgid if not applicable) is returned with any mapped values
  applied.
