### PR TITLE
translate() to pass context to translator() so translator() can get request data without using globals

### DIFF
--- a/translationstring/__init__.py
+++ b/translationstring/__init__.py
@@ -207,7 +207,7 @@ def ChameleonTranslate(translator):
         if translator is None:
             result = tstring.interpolate()
         else:
-            result = translator(tstring)
+            result = translator(tstring, context)
 
         return result
 


### PR DESCRIPTION
translate() has  context=None in the method signature but it is not used. If it is passed to translator(), then translator would not need to do get_current_request() (not green thread safe) in Pyramid.
