### PR TITLE
Stopped the TranslationStringFactory from steamrolling the domain of an ...

### DIFF
--- a/translationstring/__init__.py
+++ b/translationstring/__init__.py
@@ -128,7 +128,7 @@ class TranslationString(text_type):
     def __getstate__(self):
         return text_type(self), self.domain, self.default, self.mapping
 
-def TranslationStringFactory(domain):
+def TranslationStringFactory(factory_domain):
     """ Create a factory which will generate translation strings
     without requiring that each call to the factory be passed a
     ``domain`` value.  A single argument is passed to this class'
@@ -143,6 +143,14 @@ def TranslationStringFactory(domain):
         """ Provided a msgid (Unicode object or :term:`translation
         string`) and optionally a mapping object, and a *default
         value*, return a :term:`translation string` object."""
+
+        # if we are passing in a TranslationString as the msgid, then
+        # use its domain
+        if isinstance(msgid, TranslationString):
+            domain = msgid.domain or factory_domain
+        else:
+            domain = factory_domain
+
         return TranslationString(msgid, domain=domain, default=default,
                                  mapping=mapping)
     return create

--- a/translationstring/tests/test__init__.py
+++ b/translationstring/tests/test__init__.py
@@ -140,6 +140,27 @@ class TestTranslationStringFactory(unittest.TestCase):
         self.assertEqual(inst.mapping, 'mapping')
         self.assertEqual(inst.default, 'default')
 
+    def test_msgid_is_translation_string_override_domain(self):
+        user_factory = self._makeOne('user')
+        factory = self._makeOne('budge')
+
+        wrapped_inst = user_factory('wrapped_msgid', mapping={'a':1}, default='default')
+        wrapper_inst = factory(wrapped_inst)
+
+        self.assertEqual(str(wrapper_inst), 'wrapped_msgid')
+        self.assertEqual(wrapper_inst.domain, 'user')
+
+    def test_msgid_is_translation_string_override_kwarg(self):
+        user_factory = self._makeOne('user')
+        factory = self._makeOne('budge')
+
+        wrapped_inst = user_factory('wrapped_msgid', mapping={'a':1}, default='default')
+        wrapper_inst = factory(wrapped_inst, mapping={'b':1}, default='other_default')
+
+        self.assertEqual(str(wrapper_inst), 'wrapped_msgid')
+        self.assertEqual(wrapper_inst.mapping, {'b':1})
+        self.assertEqual(wrapper_inst.default, 'other_default')
+
 
 class TestChameleonTranslate(unittest.TestCase):
     def _makeOne(self, translator):


### PR DESCRIPTION
...incoming msgid, which is a TranslationString.
