### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"

--- a/changes.rst
+++ b/changes.rst
@@ -4,7 +4,7 @@ translationstring
 1.4 (unreleased)
 ----------------
 
-- ..
+- Drop support for Python 2.6
 
 
 1.3 (2014-11-05)

--- a/changes.rst
+++ b/changes.rst
@@ -5,6 +5,7 @@ translationstring
 ----------------
 
 - Drop support for Python 2.6
+- Drop support for Python 3.2
 
 
 1.3 (2014-11-05)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
       "Development Status :: 5 - Production/Stable",
       "Intended Audience :: Developers",
       "Programming Language :: Python :: 2",
-      "Programming Language :: Python :: 2.6",
       "Programming Language :: Python :: 2.7",
       "Programming Language :: Python :: 3",
       "Programming Language :: Python :: 3.2",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
       "Programming Language :: Python :: 2",
       "Programming Language :: Python :: 2.7",
       "Programming Language :: Python :: 3",
-      "Programming Language :: Python :: 3.2",
       "Programming Language :: Python :: 3.3",
       "Programming Language :: Python :: 3.4",
       "Programming Language :: Python :: 3.5",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-envlist = 
-    py26,py27,py32,py33,py34,py35,pypy,cover,docs
+envlist =
+    py27,py32,py33,py34,py35,pypy,cover,docs
 
 [testenv]
 commands = 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py32,py33,py34,py35,pypy,cover,docs
+    py27,py33,py34,py35,pypy,cover,docs
 
 [testenv]
 commands = 


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.
