### PR TITLE
Fix python 3.3 path in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
   - "3.4"
   - "3.5"
   - pypy
+matrix:
+  include:
+    - python: 3.3
+      dist: trusty
 install:
   - pip install .
 script: python setup.py test -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - pypy


### PR DESCRIPTION
Due to python 3.3 not available anymore in default travis ubuntu version (now 16.04, xenial), python 3.3 is taken from 14.04 (trusty) instead.

Fix taken from https://github.com/travis-ci/travis-ci/issues/9133#issuecomment-531022359

Fixes failing jobs like this one: https://travis-ci.org/github/Pylons/translationstring/jobs/704319398